### PR TITLE
Add support for building with MSVC for x64 Windows (#33)

### DIFF
--- a/Makefile.wnm
+++ b/Makefile.wnm
@@ -7,11 +7,11 @@ CC = cl
 
 # Normal flags
 CFLAGS = /nologo /MD /W3 /EHsc /O2 /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c 
-LDFLAGS = /nologo /subsystem:console /incremental:no /machine:I386
+LDFLAGS = /nologo /subsystem:console /incremental:no
 
 # Debugging flags
 #CFLAGS = /nologo /MDd /W3 /GX /Od /Gm /Zi /I "." /D "WIN32" /D "NDEBUG" /D "_CONSOLE" /c
-#LDFLAGS = /nologo /subsystem:console /incremental:yes /debug /machine:I386
+#LDFLAGS = /nologo /subsystem:console /incremental:yes /debug
 
 LD = link
 LIBS = user32.lib

--- a/lglob.h
+++ b/lglob.h
@@ -62,7 +62,7 @@
 					char dir[_MAX_DIR];	\
 					char fname[_MAX_FNAME];	\
 					char ext[_MAX_EXT];	\
-					long handle;
+					intptr_t handle;
 
 #else
 #if MSDOS_COMPILER==WIN32C && !defined(_MSC_VER) /* Borland C for Windows */


### PR DESCRIPTION
* Make lglob not crash when it's built with MSVC x64

The return type of _findfirst is intptr_t. When the target is x64,
intptr_t is 64-bit, while long is 32-bit, so using long truncates
the result.

* Makefile.wnm: don't hardcode the I386 machine type

This allows building for either I386 or x64 with the same makefile,
by running it in the appropriate environment.